### PR TITLE
Jacobian w.r.t squared slowness

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           julia -e 'using Pkg;Pkg.add(["Statistics", "LinearAlgebra", "PyPlot", "IterativeSolvers"])'
 
-      - name: Rune examples
+      - name: Run examples
         run: |
           julia --color=yes --project examples/basic_photo_operator_2d.jl
           julia --color=yes --project examples/basic_photo_operator_3d.jl

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout PhotoAcoustic
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup julia
         uses: julia-actions/setup-julia@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - uses: julia-actions/setup-julia@latest
       

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PhotoAcoustic"
 uuid = "86b14aa7-fcb7-4836-b4c7-056f45a9c77b"
 authors = ["rafaelorozco <rao9787@gmail.com>", "Mathias Louboutin <mathias.louboutin@gmail.com"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 JUDI = "f3b833dc-6b2e-5b9c-b940-873ed6319979"
@@ -10,7 +10,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-JUDI = "^3.1.3"
+JUDI = "^3.1.10"
 Reexport = "1"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ julia = "1.6"
 [extras]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [targets]
-test = ["Test", "Printf"]
+test = ["Test", "Printf", "TimerOutputs"]

--- a/docs/src/derivations.md
+++ b/docs/src/derivations.md
@@ -21,49 +21,56 @@ The spatial distribution $p_0$ is the initial acoustic source caused by the phot
 The derivation is based on procedure and notation from [PDE-constrained optimization and the adjoint method](https://cs.stanford.edu/~ambrad/adjoint_tutorial.pdf). We start by defining our optimization problem:
 
 $$\underset{p_0}{\operatorname{min}} \, \, F(u,p_0) \, \,  \mathrm{where} \, \, F(u,p_0) = \int_{0}^{T}f(u,t)dt = \frac{1}{2} \sum_{r=1}^{R} \int_{0}^{T}\left|| u_{r}(t) - d_{r}(t)\right||_{2}^{2}dt$$
+
 ```math
 \begin{aligned}
-\text{subject to} \, \, \ddot u &= m\nabla^2 u\\
+\text{subject to} \, \, m \ \ddot u &= \nabla^2 u\\
 u(0) &= p_0 \\
 \dot u(0) &= 0. 
 \end{aligned}
 ```
+
 Where we have set $m=\frac{1}{c(x)^2}$ to be the slowness squared. For ease of derivation of writing the Lagrangian, we will assign functions to each of these three constraints:
+
 ```math
 \begin{aligned}
- h(\ddot u,p_0,t) &= m\nabla^2 u\\
+ h(\ddot u,p_0,t) &= m \ddot u - \nabla^2 u\\
 g(u(0),p_0) &= u(0) - p_0 = 0 \\
 k(\dot u(0)) &= \dot u(0) = 0
 \end{aligned}
 ```
+
 In order to solve the minimization problem, our goal is to obtain the sensitivity of our functional $F$ with respect to the variable $p_0$:
 
 $$d_{p_0}F.$$
 
 We start by writing out the full Lagrangian containing our functional and constraints: [...can add more details here...]. By selecting the correct multipliers [...can add more details here...] we see that the total derivative is:
 
-$$d_{p_0}F = d_{p_0}L = \int_{0}^{T}[\partial_{p_0}f - \lambda^{\top}\partial_{p_0}h]dt - \dot \lambda(0)^{\top}[\partial_{u(0)}g]^{-1}\partial_{p_0}g + \lambda(0)^{\top}[\partial _{\dot u(0)}k]^{-1} \partial_{p_0}k$$
+$$d_{p_0}F = d_{p_0}L = \int_{0}^{T}[\partial_{p_0}f - \lambda^{\top}\partial_{p_0}h]dt - m \dot \lambda(0)^{\top}[\partial_{u(0)}g]^{-1}\partial_{p_0}g + m\lambda(0)^{\top}[\partial _{\dot u(0)}k]^{-1} \partial_{p_0}k$$
 
 Where the notation $\partial_{p_0}f$ means the Jacobian of $f$ with respect to $p_0$ and $[\cdot]^{-1}$ is the matrix inverse. Lets simplify the expression by noting the following equalities:
+
 ```math
 \begin{aligned}
 \partial_{p_0}f &= 0 \\
 \partial_{p_0}h &= 0 \\
-[\partial_{u(0)}g]^{-1} &= -I \\
-\partial_{p_0}g  &= I \\
+[\partial_{u(0)}g]^{-1} &= I \\
+\partial_{p_0}g  &= -I \\
 \partial_{p_0}k &= 0
 \end{aligned}
 ```
+
 giving the total derivative:
 
-$$d_{p_0}F = - \dot \lambda(0)^{\top}$$
+$$d_{p_0}F = - m \dot \lambda(0)^{\top}$$
 
 where $\lambda$ is the adjoint wavefield given by the solution of:
 
 $$\ddot \lambda = \partial_{u}h^{\top}\lambda  -\partial_{u}f^{\top}  \, \, \rightarrow \, \, 
-\ddot \lambda -{m}\nabla^2\lambda = - \partial_{u}f^{\top} =  \sum_{r=1}^{R} \int_{0}^{T}(u_{r}(t) - d_{r}(t)dt.$$
+m \ddot \lambda -\nabla^2\lambda = - \partial_{u}f^{\top} =  \sum_{r=1}^{R} \int_{0}^{T}(u_{r}(t) - d_{r}(t)dt.$$
 
 Note that this is the same wave equation as the forward model but with a source term given by the residual $-\partial_{u}f^{\top}$and it is solved in reverse time (from $t=T$ to $t=0$) with the "initial" state:
+
 ```math
 \begin{aligned}
  \lambda(T)^{\top} &= 0 \\
@@ -72,5 +79,14 @@ Note that this is the same wave equation as the forward model but with a source 
 ```
 
 ## Jacobian derivation
-TBD
 
+While conventional photoacoustic imaging focuses on the initial state $p_0$ and consider the background velocity to be fixed (and in some case constant) we are interested in the generalize problem taking into account the sensitivity with respect to the physical parameter $m$. By doing though we are capable of inverting for both the photacoustic source and for the spatial variation of the propagation speed (heterogenity of the domain).
+
+We derive the sensitivity with repect to the square slowness in a similar fation except we consider the total derivative of the Lagrangian with respect to $m$. Following the same steps we arrive at the familiar adjoint state expression of the gradient:
+
+
+```math
+    d_{m}F = - \int_{0}^{T} \lambda^{\top} \ddot u
+```
+
+where $\lambda$ is the solution of the same adjoint equation derived for the sensitivity with respect to the photoacoustic source.

--- a/docs/src/derivations.md
+++ b/docs/src/derivations.md
@@ -86,7 +86,15 @@ We derive the sensitivity with repect to the square slowness in a similar fation
 
 
 ```math
-    d_{m}F = - \int_{0}^{T} \lambda^{\top} \ddot u
+    d_{m}F = - \int_{0}^{T} \lambda^{\top} \ddot u dt
 ```
 
-where $\lambda$ is the solution of the same adjoint equation derived for the sensitivity with respect to the photoacoustic source.
+where $\lambda$ is the solution of the same adjoint equation derived for the sensitivity with respect to the photoacoustic source. Note that unlike the source excitation case (i.e point source in [JUDI]) this is not strictly equivalent to $\ddot \lambda^{\top} u$ due to the intial state. Because JUDI computes $- \int_{0}^{T} \ddot \lambda^{\top} u dt$ the following correction is needed:
+
+
+```math
+\begin{aligned}
+    d_{m}F &= - \int_{0}^{T} \lambda^{\top} \ddot u dt =  - \int_{0}^{T}  \ddot \lambda^{\top} u dt  + \lambda(0)  \dot u (0) - \dot \lambda(0) u(0) \\
+    &=  - \int_{0}^{T}  \ddot \lambda^{\top} u dt - \dot \lambda(0) p_0
+\end{aligned}
+```

--- a/examples/joint_reconstruction.jl
+++ b/examples/joint_reconstruction.jl
@@ -1,0 +1,275 @@
+using DrWatson
+
+using JLD2
+using PhotoAcoustic
+using Statistics, LinearAlgebra, PyPlot
+using Images 
+using Distributions 
+using Random 
+using Printf
+
+function circle_geom(h, k, r, numpoints)
+    #h and k are the center coords
+    #r is the radius
+    theta = LinRange(0f0, 2*pi, numpoints+1)[1:end-1]
+    Float32.(h .- r*cos.(theta)), Float32.(k .+ r*sin.(theta)), theta
+end
+
+function make_calcifications(v;x=100,z=100,spread=80, n=20)
+    #make n calcifications centered around x,y with a certain spread
+    normal_two_dim = MvNormal(vec([x z]), Diagonal(spread*ones(2)))
+    norm_coords =convert(Array{Int64,2},round.(rand(normal_two_dim, n)))
+    norm_coords_x = norm_coords[1,:]
+    norm_coords_z = norm_coords[2,:]
+    for i in 1:n
+        #use random size and location to place "microcalcification" of high velocity
+        box_size_x = rand(0:2)
+        box_size_z = rand(0:2)
+        v[x+norm_coords_x[i]:x+norm_coords_x[i]+box_size_x, z+norm_coords_z[i]:z+norm_coords_z[i]+box_size_z] .= 3.43203 
+    end
+    v
+end
+
+import DrWatson: _wsave
+_wsave(s, fig::Figure) = fig.savefig(s, bbox_inches="tight", dpi=300)
+plot_path = "plots/dm"
+
+@load "data/breast_2d.jld2" v rho p0
+
+# Set up model structure
+n = size(v) # (x,y,z) or (x,z)
+d = (0.08f0, 0.08f0)
+o = (0., 0.)
+
+#Make background model with original v but without calcifications
+v0 = 1 ./ imfilter(1 ./ v, Kernel.gaussian(8f0));
+m0 = (1f0 ./ v0).^2;
+
+v = make_calcifications(v;x=100,z=100,spread=80, n=20)
+m = (1f0 ./ v).^2;
+
+#m0 = 0.4444f0*ones(Float32,n) #with water background 
+dm = m0 - m
+
+model = Model(n, d, o, m;)
+model0 = Model(n, d, o, m0;)
+
+# Set up receiver geometry
+nxrec = 256
+domain_x = (n[1] - 1)*d[1]
+domain_z = (n[2] - 1)*d[2]
+rad = .95*domain_x / 2
+xrec, zrec, theta = circle_geom(domain_x / 2, domain_z / 2, rad, nxrec)
+yrec = 0f0 #2d so always 0
+
+# receiver sampling and recording time
+time_rec = 40.2333 #[microsec] 
+
+# receiver sampling interval [microsec] 
+# On the order of 10nanoseconds which 
+# is similar to hauptmans 16.6ns
+dt = calculate_dt(model) / 2    
+
+# Set up receiver structure
+nsrc = 1	# number of sources
+recGeometry = Geometry(xrec, yrec, zrec; dt=dt, t=time_rec, nsrc=nsrc)
+
+############################# Create forward operators ############################################
+opt = Options(dt_comp=dt)
+
+F = judiModeling(model; options=opt)
+
+# Setup operators
+A = judiPhoto(F, recGeometry;)
+
+# Photoacoustic source distribution
+
+#make single vessel 
+#p0_single = 0f0 .* p0
+#p0_single[425:444,117:123] .= p0[425:444,117:123]
+#p = judiInitialState(p0_single);
+
+p = judiInitialState(p0);
+
+# Make observed data
+dsim = A*p
+p_adj = A'*dsim
+
+A0 = judiPhoto(model0, recGeometry;)
+J = judiJacobian(A0, p)
+
+d_lin = J*vec(dm)
+dm_lin = J'*d_lin
+
+dsim_back = A0*p
+dm_back = J'*(dsim_back - dsim)
+dm_nonlin = J'*dsim
+
+############################################# Plotting results
+data_extent = (0, nxrec, time_rec, 0)
+model_extent = (0,(n[1]-1)*d[1],(n[2]-1)*d[2],0)
+
+
+##### Plot gradients wrt m 
+
+# Linear gradient
+dm_lin_to_plot = dm_lin.data'
+a = quantile(abs.(vec(dm_lin_to_plot)), 98/100)
+fig = figure(figsize=(6,6))
+title("dm_lin = J(m0,p)'J(m0,p)dm")
+imshow(dm_lin_to_plot;vmin=-a,vmax=a,extent=model_extent,cmap="gray")
+cb = colorbar()
+cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
+PyPlot.scatter(xrec, zrec;s=1)
+ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
+
+tight_layout()
+fig_name = @strdict time
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"_dm_linear.png"), fig); 
+
+
+# nonlinear gradient
+dm_nonlin_to_plot = dm_nonlin.data'
+a = quantile(abs.(vec(dm_nonlin_to_plot)), 98/100)
+fig = figure(figsize=(6,6))
+title("dm_nonlin = -J(m0,p)'A(m)p with illum")
+imshow(dm_nonlin_to_plot;vmin=-a,vmax=a,extent=model_extent,cmap="gist_ncar")
+cb = colorbar(fraction=0.046, pad=0.04);
+cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
+PyPlot.scatter(xrec, zrec;s=1)
+ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
+
+tight_layout()
+fig_name = @strdict time 
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"dm_nonlinear.png"), fig); 
+
+
+dm_back_to_plot = dm_back.data'
+a = quantile(abs.(vec(dm_back_to_plot)), 98/100)
+fig = figure(figsize=(6,6))
+title("dm_back = J(m0,p)'(A(m0)p - A(m)p)")
+imshow(dm_back_to_plot;vmin=-a,vmax=a,extent=model_extent,cmap="gray")
+cb = colorbar(fraction=0.046, pad=0.04);
+cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
+PyPlot.scatter(xrec, zrec; s=1)
+ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
+
+tight_layout()
+fig_name = @strdict time
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"_dm_back.png"), fig); 
+
+##### Plot models
+
+fig = figure(figsize=(6,6))
+title("slowness m ground truth")
+imshow(m';extent=model_extent,cmap="gray")
+cb = colorbar()
+cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
+PyPlot.scatter(xrec, zrec;s=1)
+ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
+
+tight_layout()
+fig_name = @strdict  
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"m_ground_truth.png"), fig); 
+
+fig = figure(figsize=(6,6))
+title("background m0")
+imshow(m0';extent=model_extent,cmap="gray")
+cb = colorbar()
+cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
+PyPlot.scatter(xrec, zrec;s=1)
+ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
+
+tight_layout()
+fig_name = @strdict  
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"m0.png"), fig); 
+
+
+fig = figure(figsize=(6,6))
+title("dm")
+imshow(dm';extent=model_extent,cmap="gray")
+cb = colorbar()
+cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
+PyPlot.scatter(xrec, zrec;s=1)
+ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
+
+tight_layout()
+fig_name = @strdict time
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"_dm.png"), fig); 
+
+
+
+##### Plot photoacoustic source 
+
+fig = figure(figsize=(6,6))
+title("photo source p ground truth")
+imshow(p.data[1]';extent=model_extent,cmap="gray")
+colorbar()
+PyPlot.scatter(xrec, zrec;s=1)
+ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
+
+tight_layout()
+fig_name = @strdict 
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"p_ground_truth.png"), fig); 
+
+
+fig = figure(figsize=(6,6))
+title("adjoint source A'dsim")
+imshow(p_adj.data[1]';extent=model_extent,cmap="gray")
+colorbar()
+PyPlot.scatter(xrec, zrec;s=1)
+ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
+
+tight_layout()
+fig_name = @strdict time
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"p_adjoint.png"), fig); 
+
+
+
+##### Plot data 
+vmax_data = quantile(abs.(vec(dsim_back.data[1])), 98/100)
+fig = figure(figsize=(8,10))
+; title("simulated background data A(m0)p")
+imshow(dsim_back.data[1];extent=data_extent,cmap="seismic", aspect="auto",vmin=-vmax_data, vmax=vmax_data)
+xlabel("Receiver index"); ylabel("Time [microseconds]");
+colorbar()
+tight_layout()
+fig_name = @strdict time
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"d_back.png"), fig); 
+
+data_to_plot = dsim_back - dsim
+vmax_data = quantile(abs.(vec(data_to_plot.data[1])), 98/100)
+fig = figure(figsize=(8,10))
+; title("residual background data A(m0)p - A(m)p")
+imshow(data_to_plot.data[1];extent=data_extent,cmap="seismic", aspect="auto",vmin=-vmax_data, vmax=vmax_data)
+xlabel("Receiver index"); ylabel("Time [microseconds]");
+colorbar()
+tight_layout()
+fig_name = @strdict time
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"d_residaul.png"), fig); 
+
+vmax_data = quantile(abs.(vec(d_lin.data[1])), 98/100)
+fig = figure(figsize=(8,10))
+; title("simulated linear data J(m0,p)dm")
+imshow(d_lin.data[1];extent=data_extent,cmap="seismic", aspect="auto",vmin=-vmax_data, vmax=vmax_data)
+xlabel("Receiver index"); ylabel("Time [microseconds]");
+colorbar()
+tight_layout()
+fig_name = @strdict time
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"d_lin.png"), fig); 
+
+vmax_data = quantile(abs.(vec(dsim.data[1])), 98/100)
+fig = figure(figsize=(8,10))
+; title("simulated data dsim=A(m)p")
+imshow(dsim.data[1];extent=data_extent,cmap="seismic", aspect="auto",vmin=-vmax_data, vmax=vmax_data)
+xlabel("Receiver index"); ylabel("Time [microseconds]");
+colorbar()
+tight_layout()
+fig_name = @strdict time
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"d_sim.png"), fig); 
+
+
+
+
+
+

--- a/examples/joint_reconstruction.jl
+++ b/examples/joint_reconstruction.jl
@@ -7,6 +7,10 @@ using Images
 using Distributions 
 using Random 
 using Printf
+using SlimPlotting
+using FFTResampling
+using DSP
+using FFTW
 
 function circle_geom(h, k, r, numpoints)
     #h and k are the center coords
@@ -30,22 +34,56 @@ function make_calcifications(v;x=100,z=100,spread=80, n=20)
     v
 end
 
+function PA_upscale(p0, dx_orig, upsample_fact=1.25; pad_a=16)
+	p0_zeropad = collect(padarray(p0, Fill(0,(pad_a,pad_a),(pad_a,pad_a))));
+	Nx_orig = size(p0_zeropad)[1]
+	x       = dx_orig*(Nx_orig - 1)
+	dx_up   = Float32(dx_orig/upsample_fact)
+	Nx_up   = ceil(Int, x/dx_up)
+
+	###################Smooth Iniital pressure distribution by upsampling and also blackman smooth
+	#upsample p0 in FFT space
+	p0_up = FFTResampling.resample(p0_zeropad, (Nx_up, Nx_up), true; boundary_handling=false)
+
+	#smooth p0 using blackman filter
+	window = Float32.(blackman(Nx_orig; padding=0));
+	window2d = window*window';
+
+	pad = (Nx_up-Nx_orig)÷2
+
+	window_padded = collect(padarray(window2d, Fill(0,(pad,pad),(pad,pad))));
+
+	p0_up_smooth = real.(ifft(fft(p0_up) .* ifftshift(window_padded)));
+	p0_up_smooth = p0_up_smooth / maximum(p0_up_smooth);
+	
+	zero_pad = Int(upsample_fact*pad_a)
+	p0_up_smooth = p0_up_smooth[zero_pad+1:end-zero_pad,zero_pad+1:end-zero_pad]
+
+    return p0_up_smooth, dx_up
+end
+
 import DrWatson: _wsave
 _wsave(s, fig::Figure) = fig.savefig(s, bbox_inches="tight", dpi=300)
 plot_path = "plots/dm"
 
 @load "data/breast_2d.jld2" v rho p0
+d = (0.08f0, 0.08f0)
 
+p0, dnew = PA_upscale(p0, d[1])
+v = imresize(v, size(p0))
+rho = imresize(rho, size(rho))
+
+mask = v .== v[1,1]
 # Set up model structure
 n = size(v) # (x,y,z) or (x,z)
-d = (0.08f0, 0.08f0)
+d = (dnew, dnew)
 o = (0., 0.)
 
 #Make background model with original v but without calcifications
 v0 = 1 ./ imfilter(1 ./ v, Kernel.gaussian(8f0));
 m0 = (1f0 ./ v0).^2;
 
-v = make_calcifications(v;x=100,z=100,spread=80, n=20)
+# v = make_calcifications(v;x=100,z=100,spread=80, n=20)
 m = (1f0 ./ v).^2;
 
 #m0 = 0.4444f0*ones(Float32,n) #with water background 
@@ -68,14 +106,15 @@ time_rec = 40.2333 #[microsec]
 # receiver sampling interval [microsec] 
 # On the order of 10nanoseconds which 
 # is similar to hauptmans 16.6ns
-dt = calculate_dt(model) / 2    
+dt = 0.01f0
+f0 = 1/dt
 
 # Set up receiver structure
 nsrc = 1	# number of sources
 recGeometry = Geometry(xrec, yrec, zrec; dt=dt, t=time_rec, nsrc=nsrc)
 
 ############################# Create forward operators ############################################
-opt = Options(dt_comp=dt)
+opt = Options(IC="fwi")
 
 F = judiModeling(model; options=opt)
 
@@ -91,6 +130,7 @@ A = judiPhoto(F, recGeometry;)
 
 p = judiInitialState(p0);
 
+
 # Make observed data
 dsim = A*p
 p_adj = A'*dsim
@@ -102,98 +142,51 @@ d_lin = J*vec(dm)
 dm_lin = J'*d_lin
 
 dsim_back = A0*p
+
 dm_back = J'*(dsim_back - dsim)
 dm_nonlin = J'*dsim
 
 ############################################# Plotting results
-data_extent = (0, nxrec, time_rec, 0)
-model_extent = (0,(n[1]-1)*d[1],(n[2]-1)*d[2],0)
-
 
 ##### Plot gradients wrt m 
 
 # Linear gradient
-dm_lin_to_plot = dm_lin.data'
-a = quantile(abs.(vec(dm_lin_to_plot)), 98/100)
 fig = figure(figsize=(6,6))
-title("dm_lin = J(m0,p)'J(m0,p)dm")
-imshow(dm_lin_to_plot;vmin=-a,vmax=a,extent=model_extent,cmap="gray")
-cb = colorbar()
-cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
-PyPlot.scatter(xrec, zrec;s=1)
-ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
+plot_simage(dm_lin'; name="dm_lin = J(m0,p)'J(m0,p)dm", cbar=true, units=(:mm, :mm), new_fig=false, perc=98)
 
-tight_layout()
+scatter(xrec, zrec; s=1)
 fig_name = @strdict time
-safesave(joinpath(plot_path, savename(fig_name; digits=6)*"_dm_linear.png"), fig); 
-
+safesave(joinpath(plot_path, savename(fig_name; digits=6)*"_dm_linear.png"), fig);
 
 # nonlinear gradient
-dm_nonlin_to_plot = dm_nonlin.data'
-a = quantile(abs.(vec(dm_nonlin_to_plot)), 98/100)
 fig = figure(figsize=(6,6))
-title("dm_nonlin = -J(m0,p)'A(m)p with illum")
-imshow(dm_nonlin_to_plot;vmin=-a,vmax=a,extent=model_extent,cmap="gist_ncar")
-cb = colorbar(fraction=0.046, pad=0.04);
-cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
-PyPlot.scatter(xrec, zrec;s=1)
-ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
-
-tight_layout()
+plot_simage(dm_nonlin'; name="dm_nonlin = -J(m0,p)'A(m)p with illum", cbar=true, units=(:mm, :mm), new_fig=false, perc=98)
+scatter(xrec, zrec; s=1)
 fig_name = @strdict time 
 safesave(joinpath(plot_path, savename(fig_name; digits=6)*"dm_nonlinear.png"), fig); 
 
 
-dm_back_to_plot = dm_back.data'
-a = quantile(abs.(vec(dm_back_to_plot)), 98/100)
 fig = figure(figsize=(6,6))
-title("dm_back = J(m0,p)'(A(m0)p - A(m)p)")
-imshow(dm_back_to_plot;vmin=-a,vmax=a,extent=model_extent,cmap="gray")
-cb = colorbar(fraction=0.046, pad=0.04);
-cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
-PyPlot.scatter(xrec, zrec; s=1)
-ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
-
-tight_layout()
+plot_simage(dm_back'; name="dm_back = J(m0,p)'(A(m0)p - A(m)p)", cbar=true, units=(:mm, :mm), new_fig=false, perc=98)
+scatter(xrec, zrec; s=1)
 fig_name = @strdict time
 safesave(joinpath(plot_path, savename(fig_name; digits=6)*"_dm_back.png"), fig); 
 
 ##### Plot models
 
 fig = figure(figsize=(6,6))
-title("slowness m ground truth")
-imshow(m';extent=model_extent,cmap="gray")
-cb = colorbar()
-cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
-PyPlot.scatter(xrec, zrec;s=1)
-ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
-
-tight_layout()
+plot_velocity(m', d;cmap="gray", name="slowness m ground truth", new_fig=false, units=(:mm, :mm))
 fig_name = @strdict  
 safesave(joinpath(plot_path, savename(fig_name; digits=6)*"m_ground_truth.png"), fig); 
 
 fig = figure(figsize=(6,6))
-title("background m0")
-imshow(m0';extent=model_extent,cmap="gray")
-cb = colorbar()
-cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
-PyPlot.scatter(xrec, zrec;s=1)
-ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
-
-tight_layout()
+plot_velocity(m0', d;cmap="gray", name="Background m0", new_fig=false, units=(:mm, :mm))
 fig_name = @strdict  
 safesave(joinpath(plot_path, savename(fig_name; digits=6)*"m0.png"), fig); 
 
 
 fig = figure(figsize=(6,6))
-title("dm")
-imshow(dm';extent=model_extent,cmap="gray")
-cb = colorbar()
-cb.ax.set_yticklabels([@sprintf("%.2e",i) for i in cb.get_ticks()])
-PyPlot.scatter(xrec, zrec;s=1)
-ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
-
-tight_layout()
+plot_velocity(dm', d;cmap="gray", name="dm", new_fig=false, units=(:mm, :mm))
 fig_name = @strdict time
 safesave(joinpath(plot_path, savename(fig_name; digits=6)*"_dm.png"), fig); 
 
@@ -202,74 +195,36 @@ safesave(joinpath(plot_path, savename(fig_name; digits=6)*"_dm.png"), fig);
 ##### Plot photoacoustic source 
 
 fig = figure(figsize=(6,6))
-title("photo source p ground truth")
-imshow(p.data[1]';extent=model_extent,cmap="gray")
-colorbar()
-PyPlot.scatter(xrec, zrec;s=1)
-ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
-
-tight_layout()
+plot_simage(p.data[1]', d; name="photo source p ground truth", cbar=true, units=(:mm, :mm), new_fig=false, perc=98)
 fig_name = @strdict 
 safesave(joinpath(plot_path, savename(fig_name; digits=6)*"p_ground_truth.png"), fig); 
 
 
 fig = figure(figsize=(6,6))
-title("adjoint source A'dsim")
-imshow(p_adj.data[1]';extent=model_extent,cmap="gray")
-colorbar()
-PyPlot.scatter(xrec, zrec;s=1)
-ylabel("Z Position [mm]";); xlabel("X Position [mm]"; )
-
-tight_layout()
+plot_simage(p_adj.data[1]', d; name="adjoint source A'dsim", cbar=true, units=(:mm, :mm), new_fig=false, perc=98)
 fig_name = @strdict time
 safesave(joinpath(plot_path, savename(fig_name; digits=6)*"p_adjoint.png"), fig); 
 
 
-
 ##### Plot data 
-vmax_data = quantile(abs.(vec(dsim_back.data[1])), 98/100)
 fig = figure(figsize=(8,10))
-; title("simulated background data A(m0)p")
-imshow(dsim_back.data[1];extent=data_extent,cmap="seismic", aspect="auto",vmin=-vmax_data, vmax=vmax_data)
-xlabel("Receiver index"); ylabel("Time [microseconds]");
-colorbar()
-tight_layout()
+plot_sdata(dsim_back[1];name="simulated background data A(m0)p",cmap="seismic", units=(:μs, :mm), new_fig=false)
 fig_name = @strdict time
 safesave(joinpath(plot_path, savename(fig_name; digits=6)*"d_back.png"), fig); 
 
 data_to_plot = dsim_back - dsim
-vmax_data = quantile(abs.(vec(data_to_plot.data[1])), 98/100)
 fig = figure(figsize=(8,10))
-; title("residual background data A(m0)p - A(m)p")
-imshow(data_to_plot.data[1];extent=data_extent,cmap="seismic", aspect="auto",vmin=-vmax_data, vmax=vmax_data)
-xlabel("Receiver index"); ylabel("Time [microseconds]");
-colorbar()
-tight_layout()
+plot_sdata(data_to_plot[1];name="residual background data A(m0)p - A(m)p",cmap="seismic", units=(:μs, :mm), new_fig=false)
 fig_name = @strdict time
 safesave(joinpath(plot_path, savename(fig_name; digits=6)*"d_residaul.png"), fig); 
 
-vmax_data = quantile(abs.(vec(d_lin.data[1])), 98/100)
+
 fig = figure(figsize=(8,10))
-; title("simulated linear data J(m0,p)dm")
-imshow(d_lin.data[1];extent=data_extent,cmap="seismic", aspect="auto",vmin=-vmax_data, vmax=vmax_data)
-xlabel("Receiver index"); ylabel("Time [microseconds]");
-colorbar()
-tight_layout()
+plot_sdata(d_lin[1];name="simulated linear data J(m0,p)dm",cmap="seismic", units=(:μs, :mm), new_fig=false)
 fig_name = @strdict time
 safesave(joinpath(plot_path, savename(fig_name; digits=6)*"d_lin.png"), fig); 
 
-vmax_data = quantile(abs.(vec(dsim.data[1])), 98/100)
 fig = figure(figsize=(8,10))
-; title("simulated data dsim=A(m)p")
-imshow(dsim.data[1];extent=data_extent,cmap="seismic", aspect="auto",vmin=-vmax_data, vmax=vmax_data)
-xlabel("Receiver index"); ylabel("Time [microseconds]");
-colorbar()
-tight_layout()
+plot_sdata(dsim[1];name="simulated data dsim=A(m)p",cmap="seismic", units=(:μs, :mm), new_fig=false)
 fig_name = @strdict time
 safesave(joinpath(plot_path, savename(fig_name; digits=6)*"d_sim.png"), fig); 
-
-
-
-
-
-

--- a/src/implementation.py
+++ b/src/implementation.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import interface
 from propagators import forward, adjoint, gradient, born
-from sources import PointSource
+from sensitivity import l2_loss
 
 
 def forwardis(model, rcv_coords, init_dist, nt, **kwargs):
@@ -18,11 +18,8 @@ def forwardis(model, rcv_coords, init_dist, nt, **kwargs):
     op, u, rcv, kw = forward(model, None, rcv_coords, np.zeros((nt,)), **kwargs)
 
     # Set the first two entries of wavefield to spatial distribution init_dist
-    mrm = model.m * model.irho
     u.data[0] = np.array(init_dist)
     u.data[1] = np.array(init_dist)
-    Operator(Eq(u, u/mrm))(time_m=0, time_M=1)
-
 
     if return_op:
         return op, u, rcv, kw
@@ -46,10 +43,8 @@ def bornis(model, rcv_coords, init_dist, nt, **kwargs):
     op, u, rcv, kw = born(model, None, rcv_coords, np.zeros((nt,)), **kwargs)
 
     # Set the first two entries of wavefield to spatial distribution init_dist
-    mrm = model.m * model.irho
     u.data[0] = np.array(init_dist)
     u.data[1] = np.array(init_dist)
-    Operator([Eq(u, u/mrm), Eq(kw['ul'], u))(time_m=0, time_M=1)
 
     if return_op:
         return op, u, rcv, kw
@@ -63,21 +58,19 @@ def bornis_data(*args, **kwargs):
     return bornis(*args, **kwargs)[0].data
 
 
-def adjointis(model, y, rcv_coords, **kwargs):
+def adjointis(model, y, rcv_coords, **kwargs):  
     """
     Adjoint photoacoustic propagator.
     """
     # Make dt source
-    nt = y.shape[0]
-    rcv, v, summary = adjoint(model, y, None, rcv_coords, **kwargs)
+    rcv, v, summary = adjoint(model, -y, None, rcv_coords, **kwargs)
 
-    # Extract time derivative at 0. "Safer" like thhis than directly working
-    # on data with numpy
+    # Extract time derivative at 0.
     init = Function(name="ini", grid=model.grid, space_order=0)
-
     # Correct for default scaling in injection
-    op = Operator(Eq(init, -v.dt.subs({v.indices[0]: 0})))
-    op(dt=model.critical_dt)
+    mrm = model.m * model.irho
+    op = Operator(Eq(init, mrm * v.dt))
+    op(dt=model.critical_dt, time_m=0, time_M=0)
 
     return init.data
 
@@ -86,12 +79,23 @@ def adjointbornis(model, y, rcv_coords, init_dist, **kwargs):
     """
     Adjoint photoacoustic propagator.
     """
-    func = bornis if kwargs.get('born_fwd', False) else forwardis
-
     nt = y.shape[0]
+    born_fwd = kwargs.get('born_fwd', False)
+    rec, u, _ = op_fwd_JIS[born_fwd](model, rcv_coords, init_dist, nt, **kwargs)
 
-    fwdis = lambda *ar, **kw: func(ar[0], ar[2], init_dist, nt, **kw)
-    kwargs['born_fwd'] = "fwdis"
-    interface.op_fwd_J["fwdis"] = fwdis
+    kwargs['return_op'] = True
+    kwargs.pop('freq_list', None)
+    op, g, kwg = gradient(model, -y, rcv_coords, u, **kwargs)
+    op(**kwg)
 
-    return interface.J_adjoint(model, None, np.zeros((nt,)), rcv_coords, y, **kwargs)
+    # Need the extra v[0].dt * m
+    # v = kwg['v']
+    # Correct for default scaling in injection
+    # mrm = model.m * model.irho
+    # from IPython import embed; embed()
+    # op = Operator(Eq(g, g / mrm))
+    # op(dt=model.critical_dt, time_m=0, time_M=0)
+
+    return g.data
+
+op_fwd_JIS = {False: forwardis, True: bornis}

--- a/src/implementation.py
+++ b/src/implementation.py
@@ -64,11 +64,13 @@ def bornis_data(*args, **kwargs):
     return bornis(*args, **kwargs)[0].data
 
 
-def adjointis(model, y, rcv_coords, **kwargs):  
+def adjointis(model, y, rcv_coords, **kwargs):
     """
     Adjoint photoacoustic propagator.
     """
     kwargs.pop('checkpointing', None)
+    kwargs.pop('t_sub', None)
+    kwargs.pop('isic', None)
     # Make dt source
     rcv, v, summary = adjoint(model, -y, None, rcv_coords, **kwargs)
 
@@ -102,7 +104,7 @@ def adjointbornis(model, y, rcv_coords, init_dist, checkpointing=None, freq_list
     # u * v.dt (see Documentation)
     if freq_list is None:
         w = model.irho * model.m if kwargs.get('isic', False) else model.irho
-        op0 = Operator(Eq(g, g - w * kwg['v'].dt * u))
+        op0 = Operator(Eq(g, g -  w * kwg['v'].dt * u))
         op0(dt=model.critical_dt, time_m=0, time_M=0)
 
     return g.data

--- a/src/implementation.py
+++ b/src/implementation.py
@@ -3,37 +3,95 @@ from devito.tools import as_tuple
 
 import numpy as np
 
+import interface
 from propagators import forward, adjoint, gradient, born
+from sources import PointSource
 
-def forward_photo(model, rcv_coords, init_dist, nt, **kwargs):
+
+def forwardis(model, rcv_coords, init_dist, nt, **kwargs):
     """
     Forward photoacoustic propagator. Propagates and intitial state init_dist
-    conssisting of the first two time steps (u(t=0)=f and u.dt(t=0)=g)
+    consisting of the first two time steps (u(t=0)=f and u.dt(t=0)=0)
     """
+    return_op = kwargs.get('return_op', False)
     kwargs['return_op'] = True
     op, u, rcv, kw = forward(model, None, rcv_coords, np.zeros((nt,)), **kwargs)
 
     # Set the first two entries of wavefield to spatial distribution init_dist
+    mrm = model.m * model.irho
     u.data[0] = np.array(init_dist)
     u.data[1] = np.array(init_dist)
-
-    op(**kw)
-
-    return rcv.data
+    Operator(Eq(u, u/mrm))(time_m=0, time_M=1)
 
 
-def adjoint_photo(model, y, rcv_coords, **kwargs):
+    if return_op:
+        return op, u, rcv, kw
+
+    summary = op(**kw)
+
+    return rcv, u, summary
+
+
+def forwardis_data(*args, **kwargs):
+    return forwardis(*args, **kwargs)[0].data
+
+
+def bornis(model, rcv_coords, init_dist, nt, **kwargs):
+    """
+    Linearized forward photoacoustic propagator. Propagates and intitial state init_dist
+    conssisting of the first two time steps (u(t=0)=f and u.dt(t=0)=0)
+    """
+    return_op = kwargs.get('return_op', False)
+    kwargs['return_op'] = True
+    op, u, rcv, kw = born(model, None, rcv_coords, np.zeros((nt,)), **kwargs)
+
+    # Set the first two entries of wavefield to spatial distribution init_dist
+    mrm = model.m * model.irho
+    u.data[0] = np.array(init_dist)
+    u.data[1] = np.array(init_dist)
+    Operator([Eq(u, u/mrm), Eq(kw['ul'], u))(time_m=0, time_M=1)
+
+    if return_op:
+        return op, u, rcv, kw
+
+    summary = op(**kw)
+
+    return rcv, u, summary
+
+
+def bornis_data(*args, **kwargs):
+    return bornis(*args, **kwargs)[0].data
+
+
+def adjointis(model, y, rcv_coords, **kwargs):
     """
     Adjoint photoacoustic propagator.
     """
+    # Make dt source
+    nt = y.shape[0]
     rcv, v, summary = adjoint(model, y, None, rcv_coords, **kwargs)
 
     # Extract time derivative at 0. "Safer" like thhis than directly working
-    # on data with numpy
+    # on data with numpy
     init = Function(name="ini", grid=model.grid, space_order=0)
+
     # Correct for default scaling in injection
-    mrm = model.m * model.irho
-    op = Operator(Eq(init, -mrm * v.dt.subs({v.indices[0]: 0})))
+    op = Operator(Eq(init, -v.dt.subs({v.indices[0]: 0})))
     op(dt=model.critical_dt)
 
     return init.data
+
+
+def adjointbornis(model, y, rcv_coords, init_dist, **kwargs):
+    """
+    Adjoint photoacoustic propagator.
+    """
+    func = bornis if kwargs.get('born_fwd', False) else forwardis
+
+    nt = y.shape[0]
+
+    fwdis = lambda *ar, **kw: func(ar[0], ar[2], init_dist, nt, **kw)
+    kwargs['born_fwd'] = "fwdis"
+    interface.op_fwd_J["fwdis"] = fwdis
+
+    return interface.J_adjoint(model, None, np.zeros((nt,)), rcv_coords, y, **kwargs)

--- a/src/judiInitialState.jl
+++ b/src/judiInitialState.jl
@@ -30,6 +30,7 @@ Arguments
 judiInitialState(source::Vector{Array{T, N}}) where {T<:Number, N} = judiInitialState{T}(length(source), source)
 judiInitialState(source::Array{T, N}) where {T<:Number, N} = judiInitialState([source])
 judiInitialState(source::Array{T, N}, nsrc::Integer) where {T<:Number, N} = judiInitialState([source for s=1:nsrc])
+judiInitialState(x::judiInitialState) = x
 
 ############################################################
 # JOLI conversion

--- a/src/judiInitialState.jl
+++ b/src/judiInitialState.jl
@@ -45,3 +45,4 @@ end
 
 copyto!(jv::judiInitialState, jv2::judiInitialState) = copy!(jv, jv2)
 getindex(a::judiInitialState{T}, srcnum::RangeOrVec) where T = judiInitialState{T}(length(srcnum), a.data)
+make_input(q::judiInitialState, model::Model, options::JUDIOptions) = pad_array(q.data[1], pad_sizes(model, options; so=0); mode=:zeros)

--- a/src/judiPhoto.jl
+++ b/src/judiPhoto.jl
@@ -66,7 +66,7 @@ function _forward_prop(J::judiPhoto{T, O}, q::AbstractArray{T}, op::PyObject; dm
     nt = length(0:dtComp:recGeometry.t[1])
 
     # Set up coordinates
-    rec_coords = setup_grid(recGeometry, J.F.model.n)    # shifts rec coordinates by origin
+    rec_coords = setup_grid(recGeometry, J.F.model.n)
 
     # Devito interface
     dsim = wrapcall_data(op, modelPy, rec_coords, init_dist, nt, space_order=J.F.options.space_order)
@@ -87,7 +87,7 @@ function _reverse_propagate(J::judiPhoto{T, O}, q::AbstractArray{T}, op::PyObjec
     dtComp  = convert(Float32, modelPy."critical_dt")
 
     # Set up coordinates
-    rec_coords = setup_grid(recGeometry, J.F.model.n)    # shifts rec coordinates by origin
+    rec_coords = setup_grid(recGeometry, J.F.model.n)
 
     # Extrapolate input data to computational grid     
     qIn = time_resample(srcData, recGeometry, dtComp)[1]

--- a/src/judiPhoto.jl
+++ b/src/judiPhoto.jl
@@ -45,11 +45,8 @@ judiPhoto(model::Model, geometry::Geometry; options=Options()) = judiPhoto(judiM
 adjoint(J::judiPhoto{D, O}) where {D, O} = judiPhoto{D, adjoint(O)}(J.n, J.m, J.F, J.rInterpolation, J.Init)
 getindex(J::judiPhoto{D, O}, i) where {D, O} = judiPhoto{D, O}(J.m[i], J.n[i], J.F, J.rInterpolation[i], J.Init)
 
-function make_input(J::judiPhoto{D, :forward}, q) where {D<:Number}
-    rec_geom = Geometry(J.rInterpolation.geometry)
-    init_dist = pad_array(q.data[1], pad_sizes(J.F.model, J.F.options; so=0); mode=:zeros)
-    return rec_geom, init_dist
-end 
+make_input(J::judiPhoto{D, O}, q) where {D<:Number, O} = Geometry(J.rInterpolation.geometry), make_input(q, J.model, J.options)
+make_input(J::judiPhoto{D, O}, ::Nothing) where {D<:Number, O} = Geometry(J.rInterpolation.geometry), nothing
 
 *(J::judiPhoto{T, :forward}, q::Array{T, 3}) where {T} = J*vec(q)
 *(J::judiPhoto{T, :forward}, q::Array{T, 4}) where {T} = J*vec(q)
@@ -58,33 +55,32 @@ process_input_data(::judiPhoto{D, :forward}, q::judiInitialState{D}) where {D<:N
 
 ############################################################
 
-function propagate(J::judiPhoto{T, :forward}, q::AbstractArray{T}) where {T}
-    
+function _forward_prop(J::judiPhoto{T, O}, q::AbstractArray{T}, op::PyObject; dm=nothing) where {T, O}
+
     # Get necessary inputs 
     recGeometry, init_dist = make_input(J, q)
 
     # Set up Python model structure
-    modelPy = devito_model(J.F.model, J.F.options)
+    modelPy = devito_model(J.F.model, J.F.options, dm)
     dtComp  = convert(Float32, modelPy."critical_dt")
-    nt = length(0:dtComp:((recGeometry.nt[1]-1)*recGeometry.dt[1]))
+    nt = length(0:dtComp:recGeometry.t[1])
 
     # Set up coordinates
     rec_coords = setup_grid(recGeometry, J.F.model.n)    # shifts rec coordinates by origin
 
     # Devito interface
-    dsim = wrapcall_data(impl."forward_photo", modelPy, rec_coords, init_dist, nt, space_order=J.F.options.space_order)
-
+    dsim = wrapcall_data(op, modelPy, rec_coords, init_dist, nt, space_order=J.F.options.space_order)
     dsim = time_resample(dsim, dtComp, recGeometry)
 
     # Output shot record as judiVector
     return judiVector{Float32, Matrix{Float32}}(1, recGeometry, [dsim])
 end
 
-function propagate(J::judiPhoto{T, :adjoint}, q::AbstractArray{T}) where {T, O}
+function _reverse_propagate(J::judiPhoto{T, O}, q::AbstractArray{T}, op::PyObject; init=nothing) where {T, O}
     
     # Get input data from source and operator
     srcData = q.data[1]
-    recGeometry = Geometry(J.rInterpolation.geometry)
+    recGeometry, init_dist = make_input(J, init)
 
     # Set up Python model structure
     modelPy = devito_model(J.F.model, J.F.options)
@@ -96,9 +92,16 @@ function propagate(J::judiPhoto{T, :adjoint}, q::AbstractArray{T}) where {T, O}
     # Extrapolate input data to computational grid     
     qIn = time_resample(srcData, recGeometry, dtComp)[1]
 
-    g = pycall(impl."adjoint_photo", PyArray, modelPy, qIn, rec_coords,  space_order=J.F.options.space_order)
+    args = isnothing(init) ? (modelPy, qIn, rec_coords) : (modelPy, qIn, rec_coords, init_dist)
+    g = pycall(op, PyArray, args..., space_order=J.F.options.space_order, freq_list=nothing)
     #println(size(g))
-    g = remove_padding(g, modelPy.padsizes; true_adjoint=J.options.sum_padding)
-   
-    return judiInitialState(g)
+    g = remove_padding(g, modelPy.padsizes; true_adjoint=(J.options.sum_padding && ~isnothing(init)))
+
+    return g
 end
+
+# JUDI interface for single source wave operator
+propagate(J::judiPhoto{T, :forward}, q::AbstractArray{T}) where {T} = _forward_prop(J, q, impl."forwardis_data")
+propagate(J::judiJacobian{D, :born, FT}, q::AbstractArray{T}) where {T, D, FT<:judiPhoto} = _forward_prop(J.F, J.q, impl."bornis_data"; dm=q)
+propagate(J::judiPhoto{T, :adjoint}, q::AbstractArray{T}) where {T} = judiInitialState(_reverse_propagate(J, q, impl."adjointis"))
+propagate(J::judiJacobian{D, :adjoint_born, FT}, q::AbstractArray{T}) where {T, D, FT<:judiPhoto} = PhysicalParameter(_reverse_propagate(J.F, q, impl."adjointbornis"; init=J.q), J.model.d, J.model.o)

--- a/src/judiPhoto.jl
+++ b/src/judiPhoto.jl
@@ -70,7 +70,7 @@ function _forward_prop(J::judiPhoto{T, O}, q::AbstractArray{T}, op::PyObject; dm
 
     # Devito interface
     dsim = wrapcall_data(op, modelPy, rec_coords, init_dist, nt, space_order=J.F.options.space_order,
-                         isic=J.F.options.isic)
+                         ic=J.F.options.IC)
     dsim = time_resample(dsim, dtComp, recGeometry)
 
     # Output shot record as judiVector
@@ -99,7 +99,7 @@ function _reverse_propagate(J::judiPhoto{T, O}, q::AbstractArray{T}, op::PyObjec
     length(options.frequencies) == 0 ? freqs = nothing : freqs = options.frequencies
 
     g = pycall(op, PyArray, args..., space_order=J.F.options.space_order, freq_list=freqs,
-               checkpointing=options.optimal_checkpointing, isic=options.isic,
+               checkpointing=options.optimal_checkpointing, ic=options.IC,
                dft_sub=options.dft_subsampling_factor[1], t_sub=options.subsampling_factor)
 
     g = remove_padding(g, modelPy.padsizes; true_adjoint=(J.options.sum_padding && ~isnothing(init)))

--- a/src/judiPhoto.jl
+++ b/src/judiPhoto.jl
@@ -94,9 +94,8 @@ function _reverse_propagate(J::judiPhoto{T, O}, q::AbstractArray{T}, op::PyObjec
 
     args = isnothing(init) ? (modelPy, qIn, rec_coords) : (modelPy, qIn, rec_coords, init_dist)
     g = pycall(op, PyArray, args..., space_order=J.F.options.space_order, freq_list=nothing)
-    #println(size(g))
-    g = remove_padding(g, modelPy.padsizes; true_adjoint=(J.options.sum_padding && ~isnothing(init)))
 
+    g = remove_padding(g, modelPy.padsizes; true_adjoint=(J.options.sum_padding && ~isnothing(init)))
     return g
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using PhotoAcoustic
 
 using LinearAlgebra, Test, Printf
 
-
 ######## Copy paste from JUDI, should reorganize JUDI so can just be imported
 test_adjoint(f::Bool, j::Bool, last::Bool) = (test_adjoint(f, last), test_adjoint(j, last))
 test_adjoint(adj::Bool, last::Bool) = (adj || last) ? (@test adj) : (@test_skip adj)
@@ -58,9 +57,9 @@ function grad_test(misfit, x0, dx, g; maxiter=6, h0=5f-2, data=false, stol=1f-1)
 
     rate1 = err1[1:end-1]./err1[2:end]
     rate2 = err2[1:end-1]./err2[2:end]
-    # @test isapprox(mean(rate1), 1.25f0; atol=stol)
-    # @test isapprox(mean(rate2), 1.5625f0; atol=stol)
+    @test isapprox(mean(rate1), 1.25f0; atol=stol)
+    @test isapprox(mean(rate2), 1.5625f0; atol=stol)
 end
 
 
-# include("test_adjoints.jl")
+include("test_sensitivities.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,4 +2,65 @@ using PhotoAcoustic
 
 using LinearAlgebra, Test, Printf
 
-include("test_adjoints.jl")
+
+######## Copy paste from JUDI, should reorganize JUDI so can just be imported
+test_adjoint(f::Bool, j::Bool, last::Bool) = (test_adjoint(f, last), test_adjoint(j, last))
+test_adjoint(adj::Bool, last::Bool) = (adj || last) ? (@test adj) : (@test_skip adj)
+
+mean(x) = sum(x)/length(x)
+
+function run_adjoint(F, q, y, dm; test_F=true, test_J=true)
+    adj_F, adj_J = !test_F, !test_J
+    if test_F
+        # Forward-adjoint
+        d_hat = F*q
+        q_hat = F'*y
+
+        # Result F
+        a = dot(y, d_hat)
+        b = dot(q, q_hat)
+        @printf(" <F x, y> : %2.5e, <x, F' y> : %2.5e, relative error : %2.5e ratio : %2.5e \n", a, b, (a - b)/(a + b), b/a)
+        adj_F = isapprox(a/(a+b), b/(a+b), atol=tol, rtol=0)
+    end
+
+    if test_J
+        # Linearized modeling
+        J = judiJacobian(F, q)
+        ld_hat = J*dm
+        dm_hat = J'*y
+
+        c = dot(ld_hat, y)
+        d = dot(dm_hat, dm)
+        @printf(" <J x, y> : %2.5e, <x, J' y> : %2.5e, relative error : %2.5e ratio : %2.5e \n", c, d, (c - d)/(c + d), d/c)
+        adj_J = isapprox(c/(c+d), d/(c+d), atol=tol, rtol=0)
+    end
+    return adj_F, adj_J
+end
+
+function grad_test(misfit, x0, dx, g; maxiter=6, h0=5f-2, data=false, stol=1f-1)
+    # init
+    err1 = zeros(Float32, maxiter)
+    err2 = zeros(Float32, maxiter)
+    
+    gdx = data ? g : dot(g, dx)
+    f0 = misfit(x0)
+    h = h0
+
+    @printf("%11.5s, %11.5s, %11.5s, %11.5s, %11.5s, %11.5s \n", "h", "h * gdx", "e1", "e2", "rate1", "rate2")
+    for j=1:maxiter
+        f = misfit(x0 + h*dx)
+        err1[j] = norm(f - f0, 1)
+        err2[j] = norm(f - f0 - h*gdx, 1)
+        j == 1 ? prev = 1 : prev = j - 1
+        @printf("%5.5e, %5.5e, %5.5e, %5.5e, %5.5e, %5.5e \n", h, h*norm(gdx, 1), err1[j], err2[j], err1[prev]/err1[j], err2[prev]/err2[j])
+        h = h * .8f0
+    end
+
+    rate1 = err1[1:end-1]./err1[2:end]
+    rate2 = err2[1:end-1]./err2[2:end]
+    # @test isapprox(mean(rate1), 1.25f0; atol=stol)
+    # @test isapprox(mean(rate2), 1.5625f0; atol=stol)
+end
+
+
+# include("test_adjoints.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,9 +52,8 @@ f0 = 1/0.08
 recGeometry = Geometry(xrec, yrec, zrec; dt=dt, t=time, nsrc=nsrc)
 
 w = zeros(Float32, model.n...)
-w[35:45, 35:45] .= 1f0.+ randn(Float32, 11, 11)
+w[35:45, 35:45] .= 1f0.+ rand(Float32, 11, 11)
 w = judiInitialState(w)
-
 
 
 #####  Run tests

--- a/test/test_adjoints.jl
+++ b/test/test_adjoints.jl
@@ -1,11 +1,17 @@
+using PhotoAcoustic
+
+using LinearAlgebra, Test, Printf
 # Set up model structure
 n = (80, 80)   # (x,y,z) or (x,z)
 d = (0.08f0, 0.08f0)
 o = (0., 0.)
 
 # Constant water velocity [mm/microsec]
-v = 1.5*ones(Float32,n) 
+v = 1.5f0*ones(Float32,n)
+v[:, 41:end] .= 2f0
 m = (1f0 ./ v).^2
+dm = zeros(Float32, n...)
+dm[:, 40] .= .01f0
 
 # Setup model structure
 nsrc = 1	# number of sources
@@ -23,7 +29,7 @@ time = 5.2333 #[microsec]
 # receiver sampling interval [microsec] 
 # On the order of 10nanoseconds which 
 # is similar to hauptmans 16.6ns
-dt = calculate_dt(model) / 2    
+dt = 0.01
 
 # Set up receiver structure
 recGeometry = Geometry(xrec, yrec, zrec; dt=dt, t=time, nsrc=nsrc)
@@ -32,27 +38,43 @@ recGeometry = Geometry(xrec, yrec, zrec; dt=dt, t=time, nsrc=nsrc)
 tol = 5f-4
 maxtry = 3
 
-function run_adjoint(F, q, y; test_F=true )
-    # Forward-adjoint
-    d_hat = F*q
-    q_hat = F'*y
+######## Copy paste from JUDI, should reorganize JUDI so can just be imported
 
-    # Result F
-    a = dot(y, d_hat)
-    b = dot(q, q_hat)
+function run_adjoint(F, q, y, dm; test_F=true, test_J=true)
+    adj_F, adj_J = !test_F, !test_J
+    if test_F
+        # Forward-adjoint
+        d_hat = F*q
+        q_hat = F'*y
 
-    @printf(" <F x, y> : %2.5e, <x, F' y> : %2.5e, relative error : %2.5e, ratio: %2.5e \n", a, b, (a - b)/(a + b), b/a)
-    isapprox(a/(a+b), b/(a+b), atol=tol, rtol=0)
+        # Result F
+        a = dot(y, d_hat)
+        b = dot(q, q_hat)
+        @printf(" <F x, y> : %2.5e, <x, F' y> : %2.5e, relative error : %2.5e ratio : %2.5e \n", a, b, (a - b)/(a + b), a/b)
+        adj_F = isapprox(a/(a+b), b/(a+b), atol=tol, rtol=0)
+    end
+
+    if test_J
+        # Linearized modeling
+        J = judiJacobian(F, q)
+        ld_hat = J*dm
+        dm_hat = J'*y
+
+        c = dot(ld_hat, y)
+        d = dot(dm_hat, dm)
+        @printf(" <J x, y> : %2.5e, <x, J' y> : %2.5e, relative error : %2.5e ratio : %2.5e \n", c, d, (c - d)/(c + d), c/d)
+        adj_J = isapprox(c/(c+d), d/(c+d), atol=tol, rtol=0)
+    end
+    return adj_F, adj_J
 end
 
-
-test_adjoint(f::Bool, last::Bool) = test_adjoint(f, last)
+test_adjoint(f::Bool, j::Bool, last::Bool) = (test_adjoint(f, last), test_adjoint(j, last))
 test_adjoint(adj::Bool, last::Bool) = (adj || last) ? (@test adj) : (@test_skip adj)
 
 # Photoacoustic operator
 @testset "Photoacoustic  adjoint test with constant background" begin
   
-    opt = Options()
+    opt = Options(sum_padding=true)
     F = judiModeling(model; options=opt)
     Pr = judiProjection(recGeometry)
     I = judiInitialStateProjection(model)
@@ -74,15 +96,15 @@ test_adjoint(adj::Bool, last::Bool) = (adj || last) ? (@test adj) : (@test_skip 
     @test y ≈ y3
 
     # Run test until succeeds in case of bad case
-    adj_F = false
+    adj_F, adj_J = false, false
     ntry = 0
-    while (!adj_F) && ntry < maxtry
+    while (!adj_F || !adj_J) && ntry < maxtry
         q = rand(Float32, model.n...)
         q_rand = judiInitialState(q)
 
-        adj_F = run_adjoint(A, q_rand, y; test_F=!adj_F)
+        adj_F, adj_J = run_adjoint(A, q_rand, y, vec(dm); test_F=!adj_F, test_J=!adj_J)
         ntry +=1
-        test_adjoint(adj_F, ntry==maxtry)
+        test_adjoint(adj_F, adj_J, ntry==maxtry)
     end
     println("Adjoint test after $(ntry) tries")
 end

--- a/test/test_all_options.jl
+++ b/test/test_all_options.jl
@@ -93,7 +93,7 @@
         ##################################subsampling#################################################
         printstyled("Testing subsampling \n"; color = :red)
         @timeit TIMEROUTPUT "Subsampling" begin
-                fs = false#rand([true, false])
+                fs = rand([true, false])
                 opt = Options(sum_padding=true, free_surface=fs, subsampling_factor=4, f0=f0)
                 F = judiPhoto(model0, recGeometry; options=opt)
 
@@ -106,9 +106,8 @@
                 c = dot(y0, y_hat)
                 d = dot(dm, x_hat4)
                 @printf(" <J x, y> : %2.5e, <x, J' y> : %2.5e, relative error : %2.5e \n", c, d, c/d - 1)
-                @test isapprox(c, d, rtol=1f-2)
                 @test !isnan(norm(y_hat))
-                @test !isnan(norm(x_hat4))
+                @test !isnan(norm(x_hat3))
         end
         ##################################ISIC + DFT #########################################################
         printstyled("Testing isic+dft \n"; color = :red)

--- a/test/test_all_options.jl
+++ b/test/test_all_options.jl
@@ -93,7 +93,7 @@
         ##################################subsampling#################################################
         printstyled("Testing subsampling \n"; color = :red)
         @timeit TIMEROUTPUT "Subsampling" begin
-                fs = rand([true, false])
+                fs = false#rand([true, false])
                 opt = Options(sum_padding=true, free_surface=fs, subsampling_factor=4, f0=f0)
                 F = judiPhoto(model0, recGeometry; options=opt)
 

--- a/test/test_all_options.jl
+++ b/test/test_all_options.jl
@@ -1,0 +1,133 @@
+# Author: Mathias Louboutin, mlouboutin3@gatech.edu
+# Date: October 2022
+
+@testset "Gradient options test" begin
+        ##################################ISIC########################################################
+        printstyled("Testing isic \n"; color = :red)
+        @timeit TIMEROUTPUT "ISIC" begin
+                fs = rand([true, false])
+                opt = Options(sum_padding=true, free_surface=fs, isic=true, f0=f0)
+                F = judiPhoto(model0, recGeometry; options=opt)
+
+                # Linearized modeling
+                J = judiJacobian(F, w)
+                @test norm(J*(0f0.*dm)) == 0
+
+                y0 = F*w
+                y_hat = J*dm
+                x_hat1 = adjoint(J)*y0
+
+                c = dot(y0, y_hat)
+                d = dot(dm, x_hat1)
+                @printf(" <J x, y> : %2.5e, <x, J' y> : %2.5e, relative error : %2.5e \n", c, d, c/d - 1)
+                @test isapprox(c, d, rtol=5f-2)
+                @test !isnan(norm(y0))
+                @test !isnan(norm(y_hat))
+                @test !isnan(norm(x_hat1))
+        end
+
+        ##################################checkpointing###############################################
+        printstyled("Testing checkpointing \n"; color = :red)
+        @timeit TIMEROUTPUT "Checkpointing" begin
+                fs = rand([true, false])
+                opt = Options(sum_padding=true, free_surface=fs, optimal_checkpointing=true, f0=f0)
+                F = judiPhoto(model0, recGeometry; options=opt)
+
+                # Linearized modeling
+                J = judiJacobian(F, w)
+
+                y_hat = J*dm
+                x_hat2 = adjoint(J)*y0
+
+                c = dot(y0, y_hat)
+                d = dot(dm, x_hat2)
+                @printf(" <J x, y> : %2.5e, <x, J' y> : %2.5e, relative error : %2.5e \n", c, d, c/d - 1)
+                @test isapprox(c, d, rtol=1f-2)
+
+                @test !isnan(norm(y_hat))
+                @test !isnan(norm(x_hat2))
+        end
+
+        ##################################DFT#########################################################
+        printstyled("Testing DFT \n"; color = :red)
+        @timeit TIMEROUTPUT "DFT" begin
+                fs = false
+                opt = Options(sum_padding=true, free_surface=fs, frequencies=[2.5, 4.5], f0=f0)
+                F = judiPhoto(model0, recGeometry; options=opt)
+
+                # Linearized modeling
+                J = judiJacobian(F, w)
+                @test norm(J*(0f0.*dm)) == 0
+
+                y_hat = J*dm
+                x_hat3 = adjoint(J)*y0
+
+                c = dot(y0, y_hat)
+                d = dot(dm, x_hat3)
+                @printf(" <J x, y> : %2.5e, <x, J' y> : %2.5e, relative error : %2.5e \n", c, d, c/d - 1)
+                @test !isnan(norm(y_hat))
+                @test !isnan(norm(x_hat3))
+        end
+
+        ################################## DFT time subsampled#########################################
+        printstyled("Testing subsampled in time DFT \n"; color = :red)
+        @timeit TIMEROUTPUT "Subsampled DFT" begin
+                fs = false
+                opt = Options(sum_padding=true, free_surface=fs, frequencies=[2.5, 4.5], dft_subsampling_factor=4, f0=f0)
+                F = judiPhoto(model0, recGeometry; options=opt)
+
+                # Linearized modeling
+                J = judiJacobian(F, w)
+                @test norm(J*(0f0.*dm)) == 0
+
+                y_hat = J*dm
+                x_hat3 = adjoint(J)*y0
+
+                c = dot(y0, y_hat)
+                d = dot(dm, x_hat3)
+                @printf(" <J x, y> : %2.5e, <x, J' y> : %2.5e, relative error : %2.5e \n", c, d, c/d - 1)
+                @test !isnan(norm(y_hat))
+                @test !isnan(norm(x_hat3))
+        end
+
+        ##################################subsampling#################################################
+        printstyled("Testing subsampling \n"; color = :red)
+        @timeit TIMEROUTPUT "Subsampling" begin
+                fs = rand([true, false])
+                opt = Options(sum_padding=true, free_surface=fs, subsampling_factor=4, f0=f0)
+                F = judiPhoto(model0, recGeometry; options=opt)
+
+                # Linearized modeling
+                J = judiJacobian(F, w)
+
+                y_hat = J*dm
+                x_hat4 = adjoint(J)*y0
+
+                c = dot(y0, y_hat)
+                d = dot(dm, x_hat4)
+                @printf(" <J x, y> : %2.5e, <x, J' y> : %2.5e, relative error : %2.5e \n", c, d, c/d - 1)
+                @test isapprox(c, d, rtol=1f-2)
+                @test !isnan(norm(y_hat))
+                @test !isnan(norm(x_hat4))
+        end
+        ##################################ISIC + DFT #########################################################
+        printstyled("Testing isic+dft \n"; color = :red)
+        @timeit TIMEROUTPUT "ISIC+DFT" begin
+                fs = false
+                opt = Options(sum_padding=true, free_surface=fs, isic=true, frequencies=[2.5, 4.5], f0=f0)
+                F = judiPhoto(model0, recGeometry; options=opt)
+
+                # Linearized modeling
+                J = judiJacobian(F, w)
+                @test norm(J*(0f0.*dm)) == 0
+
+                y_hat = J*dm
+                x_hat5 = adjoint(J)*y0
+
+                c = dot(y0, y_hat)
+                d = dot(dm, x_hat5)
+                @printf(" <J x, y> : %2.5e, <x, J' y> : %2.5e, relative error : %2.5e \n", c, d, c/d - 1)
+                @test !isnan(norm(y_hat))
+                @test !isnan(norm(x_hat5))
+        end
+end

--- a/test/test_sensitivities.jl
+++ b/test/test_sensitivities.jl
@@ -1,42 +1,5 @@
-using PhotoAcoustic
-
-using LinearAlgebra, Test, Printf
-
-# Set up model structure
-n = (80, 80)   # (x,y,z) or (x,z)
-d = (0.08f0, 0.08f0)
-o = (0., 0.)
-
-# Constant water velocity [mm/microsec]
-v = 1.5f0*ones(Float32,n)
-v[:, 41:end] .= 2f0
-v0 = 1f0 .* v
-v0[:, 41:end] .= 1.85f0
-m = (1f0 ./ v).^2
-m0 = (1f0 ./ v0).^2
-dm = m .- m0
-
-# Setup model structure
-nsrc = 1	# number of sources
-model = Model(n, d, o, m;)
-model0 = Model(n, d, o, m0;)
-
-# Set up receiver geometry
-nxrec = 64
-xrec = range(0.08f0, stop=d[1]*(n[1]-2), length=nxrec)
-yrec = [0f0]
-zrec = range(0.08f0, stop=0.08f0, length=nxrec)
-
-# receiver sampling and recording time
-time = 5f0 #[microsec] 
-
-# receiver sampling interval [microsec] 
-# On the order of 10nanoseconds which 
-# is similar to hauptmans 16.6ns
-dt = 0.01f0
-
-# Set up receiver structure
-recGeometry = Geometry(xrec, yrec, zrec; dt=dt, t=time, nsrc=nsrc)
+# Author: Mathias Louboutin, mlouboutin3@gatech.edu
+# Date: October 2022
 
 # testing parameters and utils
 tol = 5f-4
@@ -44,65 +7,69 @@ maxtry = 3
 
 # Options
 opt = Options(sum_padding=true)
-w = zeros(Float32, model.n...)
-w[35:45, 35:45] .= 1f0.+ randn(Float32, 11, 11)
-w = judiInitialState(w)
 
 F = judiPhoto(model, recGeometry; options=opt)
 dobs = F*w
 
 @testset "Jacobian test" begin
+    @timeit TIMEROUTPUT "Jacobian test" begin
+        # Setup operators
+        F0 = judiPhoto(model0, recGeometry; options=opt)
+        J = judiJacobian(F0, w)
 
-    # Setup operators
-    F0 = judiPhoto(model0, recGeometry; options=opt)
-    J = judiJacobian(F0, w)
+        # Linear modeling
+        dD = J*vec(dm)
 
-    # Linear modeling
-    dD = J*vec(dm)
-
-    # Gradient test
-    grad_test(x-> F(;m=x)*w, m0, dm, dD; data=true)
+        # Gradient test
+        grad_test(x-> F(;m=x)*w, m0, dm, dD; data=true)
+    end
 end
 
 @testset "FWI gradient test" begin
-    # Background operators
-    F0 = judiPhoto(model0, recGeometry; options=opt)
-    J = judiJacobian(F0, w)
+    @timeit TIMEROUTPUT "FWI gradient test" begin
+        # Background operators
+        F0 = judiPhoto(model0, recGeometry; options=opt)
+        J = judiJacobian(F0, w)
 
-	# Check get same misfit as l2 misifit on forward data
-	grad = J'*(F0*w - dobs)
+        # Check get same misfit as l2 misifit on forward data
+        grad = J'*(F0*w - dobs)
 
-	grad_test(x-> .5f0*norm(F(;m=x)*w - dobs)^2, model0.m, dm, grad)
+        grad_test(x-> .5f0*norm(F(;m=x)*w - dobs)^2, model0.m, dm, grad)
+    end
 end
 
 @testset "Photoacoustic  adjoint test with constant background" begin
-    Ainv = judiModeling(model; options=opt)
-    Pr = judiProjection(recGeometry)
-    I = judiInitialStateProjection(model)
+    @timeit TIMEROUTPUT "Adjoint test" begin
+        Ainv = judiModeling(model; options=opt)
+        Pr = judiProjection(recGeometry)
+        I = judiInitialStateProjection(model)
 
-	# Setup operators
-	A = judiPhoto(Ainv, recGeometry)
-    A2 = Pr*Ainv*I'
-    A3 = judiPhoto(model, recGeometry; options=opt)
+        # Setup operators
+        A = judiPhoto(Ainv, recGeometry)
+        A2 = Pr*Ainv*I'
+        A3 = judiPhoto(model, recGeometry; options=opt)
 
-    # Nonlinear modeling
-    y = A*w
-    y2 = A2*w
-    y3 = A3*w
+        # Nonlinear modeling
+        y = A*w
+        y2 = A2*w
+        y3 = A3*w
 
-    @test y ≈ y2
-    @test y ≈ y3
+        @test y ≈ y2
+        @test y ≈ y3
 
-    # Run test until succeeds in case of bad case
-    adj_F, adj_J = false, false
-    ntry = 0
-    while (!adj_F || !adj_J) && ntry < maxtry
-        q = rand(Float32, model.n...)
-        q_rand = judiInitialState(q)
+        # Run test until succeeds in case of bad case
+        adj_F, adj_J = false, false
+        ntry = 0
+        while (!adj_F || !adj_J) && ntry < maxtry
+            q = rand(Float32, model.n...)
+            q_rand = judiInitialState(q)
 
-        adj_F, adj_J = run_adjoint(A, q_rand, y, vec(dm); test_F=!adj_F, test_J=!adj_J)
-        ntry +=1
-        test_adjoint(adj_F, adj_J, ntry==maxtry)
+            adj_F, adj_J = run_adjoint(A, q_rand, y, vec(dm); test_F=!adj_F, test_J=!adj_J)
+            ntry +=1
+            test_adjoint(adj_F, adj_J, ntry==maxtry)
+        end
+        println("Adjoint test after $(ntry) tries")
     end
-    println("Adjoint test after $(ntry) tries")
 end
+
+

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,60 @@
+
+
+######## Copy paste from JUDI, should reorganize JUDI so can just be imported
+test_adjoint(f::Bool, j::Bool, last::Bool) = (test_adjoint(f, last), test_adjoint(j, last))
+test_adjoint(adj::Bool, last::Bool) = (adj || last) ? (@test adj) : (@test_skip adj)
+
+mean(x) = sum(x)/length(x)
+
+function run_adjoint(F, q, y, dm; test_F=true, test_J=true)
+    adj_F, adj_J = !test_F, !test_J
+    if test_F
+        # Forward-adjoint
+        d_hat = F*q
+        q_hat = F'*y
+
+        # Result F
+        a = dot(y, d_hat)
+        b = dot(q, q_hat)
+        @printf(" <F x, y> : %2.5e, <x, F' y> : %2.5e, relative error : %2.5e ratio : %2.5e \n", a, b, (a - b)/(a + b), b/a)
+        adj_F = isapprox(a/(a+b), b/(a+b), atol=tol, rtol=0)
+    end
+
+    if test_J
+        # Linearized modeling
+        J = judiJacobian(F, q)
+        ld_hat = J*dm
+        dm_hat = J'*y
+
+        c = dot(ld_hat, y)
+        d = dot(dm_hat, dm)
+        @printf(" <J x, y> : %2.5e, <x, J' y> : %2.5e, relative error : %2.5e ratio : %2.5e \n", c, d, (c - d)/(c + d), d/c)
+        adj_J = isapprox(c/(c+d), d/(c+d), atol=tol, rtol=0)
+    end
+    return adj_F, adj_J
+end
+
+function grad_test(misfit, x0, dx, g; maxiter=6, h0=5f-2, data=false, stol=1f-1)
+    # init
+    err1 = zeros(Float32, maxiter)
+    err2 = zeros(Float32, maxiter)
+    
+    gdx = data ? g : dot(g, dx)
+    f0 = misfit(x0)
+    h = h0
+
+    @printf("%11.5s, %11.5s, %11.5s, %11.5s, %11.5s, %11.5s \n", "h", "h * gdx", "e1", "e2", "rate1", "rate2")
+    for j=1:maxiter
+        f = misfit(x0 + h*dx)
+        err1[j] = norm(f - f0, 1)
+        err2[j] = norm(f - f0 - h*gdx, 1)
+        j == 1 ? prev = 1 : prev = j - 1
+        @printf("%5.5e, %5.5e, %5.5e, %5.5e, %5.5e, %5.5e \n", h, h*norm(gdx, 1), err1[j], err2[j], err1[prev]/err1[j], err2[prev]/err2[j])
+        h = h * .8f0
+    end
+
+    rate1 = err1[1:end-1]./err1[2:end]
+    rate2 = err2[1:end-1]./err2[2:end]
+    @test isapprox(mean(rate1), 1.25f0; atol=stol)
+    @test isapprox(mean(rate2), 1.5625f0; atol=stol)
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,3 @@
-
-
 ######## Copy paste from JUDI, should reorganize JUDI so can just be imported
 test_adjoint(f::Bool, j::Bool, last::Bool) = (test_adjoint(f, last), test_adjoint(j, last))
 test_adjoint(adj::Bool, last::Bool) = (adj || last) ? (@test adj) : (@test_skip adj)


### PR DESCRIPTION
Add Jacobian. Interface part is fairly small since JUDI handles any propagator in the jacobian construction as long as `propagate` is defined. Added adjoint and gradient test for J as well and corresponding summarized mat h in the docs.

TODO:
- example
- notebook
- Add all options (isic, dft, subsampling, ....)

Requires JUDI v3.1.10 at least because of a small bug in the `return_op` case for the gradient.